### PR TITLE
More Electron todo cleanups (for mfonville's branch)

### DIFF
--- a/src/main-process/atom-application.js
+++ b/src/main-process/atom-application.js
@@ -268,11 +268,6 @@ module.exports = class AtomApplication extends EventEmitter {
       this.safeMode
     );
 
-    // Don't await for the following method to avoid delaying the opening of a new window.
-    // (we await it just after opening it).
-    // We need to do this because `listenForArgumentsFromNewProcess()` calls `crypto.randomBytes`,
-    // which is really slow on Windows machines.
-    // (TodoElectronIssue: This got fixed in electron v3: https://github.com/electron/electron/issues/2073).
     let socketServerPromise;
     if (options.test || options.benchmark || options.benchmarkTest) {
       socketServerPromise = Promise.resolve();
@@ -280,11 +275,11 @@ module.exports = class AtomApplication extends EventEmitter {
       socketServerPromise = this.listenForArgumentsFromNewProcess();
     }
 
+    await socketServerPromise;
     this.setupDockMenu();
 
     const result = await this.launch(options);
     this.autoUpdateManager.initialize();
-    await socketServerPromise;
 
     StartupTime.addMarker('main-process:atom-application:initialize:end');
 

--- a/src/native-compile-cache.js
+++ b/src/native-compile-cache.js
@@ -38,12 +38,11 @@ class NativeCompileCache {
   }
 
   runInThisContext(code, filename) {
-    // TodoElectronIssue:  produceCachedData is deprecated after Node 10.6, so we'll
-    // will need to update this for Electron v4 to use script.createCachedData().
-    const script = new vm.Script(code, { filename, produceCachedData: true });
+    const script = new vm.Script(code, filename);
+    const cachedData = script.createCachedData();
     return {
       result: script.runInThisContext(),
-      cacheBuffer: script.cachedDataProduced ? script.cachedData : null
+      cacheBuffer: typeof cachedData !== 'undefined' ? cachedData : null
     };
   }
 

--- a/src/task.coffee
+++ b/src/task.coffee
@@ -84,23 +84,17 @@ class Task
 
   # Routes messages from the child to the appropriate event.
   handleEvents: ->
-    # TodoElectronIssue: removeAllListeners() without arguments does not work on electron v3.
-    # Remove the argument when migrating to electron v4.
-    @childProcess.removeAllListeners('message')
+    @childProcess.removeAllListeners()
     @childProcess.on 'message', ({event, args}) =>
       @emitter.emit(event, args) if @childProcess?
 
     # Catch the errors that happened before task-bootstrap.
     if @childProcess.stdout?
-      # TodoElectronIssue: removeAllListeners() without arguments does not work on electron v3.
-      # Remove the argument when migrating to electron v4.
-      @childProcess.stdout.removeAllListeners('data')
+      @childProcess.stdout.removeAllListeners()
       @childProcess.stdout.on 'data', (data) -> console.log data.toString()
 
     if @childProcess.stderr?
-      # TodoElectronIssue: removeAllListeners() without arguments does not work on electron v3.
-      # Remove the argument when migrating to electron v4.
-      @childProcess.stderr.removeAllListeners('data')
+      @childProcess.stderr.removeAllListeners()
       @childProcess.stderr.on 'data', (data) -> console.error data.toString()
 
   # Public: Starts the task.
@@ -153,11 +147,9 @@ class Task
   terminate: ->
     return false unless @childProcess?
 
-    # TodoElectronIssue: removeAllListeners() without arguments does not work on electron v3.
-    # Remove the argument when migrating to electron v4.
-    @childProcess.removeAllListeners('message')
-    @childProcess.stdout?.removeAllListeners('data')
-    @childProcess.stderr?.removeAllListeners('data')
+    @childProcess.removeAllListeners()
+    @childProcess.stdout?.removeAllListeners()
+    @childProcess.stderr?.removeAllListeners()
     @childProcess.kill()
     @childProcess = null
 


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Addressing more `ElectronTodoIssue` comments.

https://github.com/atom/atom/pull/21816#issuecomment-749843275

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

- `src/main-process/atom-application.js`
  - Remove workaround for slow [crypto.randomBytes](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback)
  - Context: `crypto.randomBytes` gets used by a listener function (which, by the way, is for tracking new windows that open and passing their options to the main window/main process (If I'm reading and understanding the comments correctly)). This listener gets initialized early on in Atom's startup. At one point, to workaround this "slow" crypto function on Windows (300 - 500 ms), the listener initialization got updated to run asynchronously, and then moved to after the first window opens. (The drawback is, this apparently creates a window for race conditions, where a second window is opened too early for the listener to catch it. So the second window isn't handled correctly. Per PR discussions.) Apparently the slow function is faster now on Windows. So we can start the listener earlier again, before the first window opens, and (according to discussions in the PRs) make it less likely there will be race conditions. (I may be misunderstanding, or the folks may have been wrong about these things in the original PRs, for all I know. But I'm making this fix assuming what they said is accurate.)
    - Original PRs: https://github.com/atom/atom/pull/19242 and https://github.com/atom/atom/pull/19246, for more context: https://github.com/atom/atom/pull/19354 and https://github.com/atom/atom/pull/19455
- `src/native-compile-cache.js`
  - produceCachedData --> script.createCachedData()
  - Use a different piece of the Node API to create this code cache. 
  - The way Atom has been using is "deprecated," but note that this "deprecation" happened a long time ago, and it is a "documentation-only deprecation" -- Node developers haven't made any public plans to actually remove the older "deprecated" API feature.
  - New way is more flexible, with some implications for which variables get cached? The details of which go right over my head... See this example: https://nodejs.org/api/vm.html#vm_script_createcacheddata
- `src/task.coffee`
  - Remove arguments from childProcess.removeAllListeners()
  - This apparently doesn't require arguments anymore, according to the `TodoElectronIssue` comment.
  - See: https://nodejs.org/api/events.html#events_emitter_removealllisteners_eventname

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- Leave these things alone, as they're working well enough already, I guess?

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Maybe ~15ms slower startup on Windows? (Maybe; See below. Supposedly prevents race conditions, so maybe worth it?)

Maybe the way I fixed these introduces new bugs? It requires a pretty deep understanding of Atom code and the Node API to get these right, and be totally confident in their correctness. To be honest, I am mostly inferring the correct solution from the code comments, PR discussions, and Node API documentation. Hopefully these are the correct fixes, but anyone is welcome to double-check them.

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Ran this through CI. If rebasing just these `ElectronTodoIssue` fixes directly on `master` branch, that passes in CI.

Also ran the built Atom from said rebased-on-master version of this branch. I didn't notice any behavior differences.

Used Atom's built-in [`timecop`](https://github.com/atom/timecop) package to monitor for slower startup on Windows. On a recent machine with an SSD, this maybe added 15 ms to startup, but with lots of run-to-run variation that made this hard to confirm. (The "Margin of error" was apparently larger than the observed effect.) (Ctrl + Shift + P to bring up the command pallette, type "timecop" to view the timecop info screen.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Addressed some old Electron upgrade "TODO" items