### PR TITLE
ci: Add newer rpm package from Bionic repositories

### DIFF
--- a/script/vsts/bionic-rpm-deb-urls.txt
+++ b/script/vsts/bionic-rpm-deb-urls.txt
@@ -1,0 +1,12 @@
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/debugedit_4.14.1+dfsg1-2_amd64.deb
+security.ubuntu.com/ubuntu/pool/main/e/elfutils/libdw1_0.170-0.4ubuntu0.1_amd64.deb
+security.ubuntu.com/ubuntu/pool/main/e/elfutils/libelf1_0.170-0.4ubuntu0.1_amd64.deb
+mirrors.kernel.org/ubuntu/pool/main/x/xz-utils/liblzma5_5.2.2-1.3_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/librpm8_4.14.1+dfsg1-2_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/librpmbuild8_4.14.1+dfsg1-2_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/librpmio8_4.14.1+dfsg1-2_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/librpmsign8_4.14.1+dfsg1-2_amd64.deb
+security.ubuntu.com/ubuntu/pool/main/libz/libzstd/libzstd1_1.3.3+dfsg-2ubuntu1.2_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/rpm2cpio_4.14.1+dfsg1-2_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/rpm_4.14.1+dfsg1-2_amd64.deb
+mirrors.kernel.org/ubuntu/pool/universe/r/rpm/rpm-common_4.14.1+dfsg1-2_amd64.deb

--- a/script/vsts/platforms/templates/preparation.yml
+++ b/script/vsts/platforms/templates/preparation.yml
@@ -10,6 +10,17 @@ steps:
     displayName: Install apt dependencies
     condition: eq(variables['Agent.OS'], 'Linux')
 
+  - script: |
+      mkdir bionic_rpm_debs && cd bionic_rpm_debs
+      for deb_URL in `cat ../script/vsts/bionic-rpm-deb-urls.txt`
+      do
+        echo "Downloading ${deb_URL}..."
+        curl -L "${deb_URL}" -O
+      done
+      sudo apt install -y ./*.deb
+      cd -
+    displayName: Install newer rpm from Bionic repos
+    condition: eq(variables['Agent.OS'], 'Linux')
 
   - script: sudo /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16
     displayName: Start Xvfb


### PR DESCRIPTION
<details><summary>Requirements for Adding, Changing, or Removing a Feature (from template, click to expand)</summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must contribute a change that has been endorsed by the maintainer team. See details in the template below.
* The pull request must update the test suite to exercise the updated functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Issue or RFC Endorsed by Atom's Maintainers

<!--

Link to the issue or RFC that your change relates to. This must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement: https://github.com/atom/.github/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

None, but it was discussed here: https://github.com/atom/atom/pull/22076#issuecomment-840675576

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Get newer the newer `rpm` package (and its missing dependencies), as `.deb` packages from the Ubuntu Bionic package repositories. This gives us newer `rpm` v4.14 in the older Ubuntu Xenial (which otherwise ships with `rpm` 4.12).

Allows the use of boolean dependencies in rpm spec files.

See: https://rpm.org/user_doc/boolean_dependencies.html for details.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

- No boolean dependencies in the rpm spec file
- Not updating the rpm spec file in general
- Building with an older, rpm-based distro in Docker, such as Fedora 23 (not sure if this would work unless tested first)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

⚠️ If these links go down, the build probably fails until they are updated to alternate (live) URLs again. ⚠️

In that case, I have copies of these `.deb`s that I could host on GitHub somewhere pretty easily. (They are all GPL-licensed, I believe. So that should be okay.) Ideally these are hosted by the Atom org somewhere, in that case. (Caveat: Must host the source code as well alongside the `.deb` binaries. I have saved copies of the source code as well to meet this requirement of the GPL.)

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Linux build completed in a CI run: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1119&view=results

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

N/A